### PR TITLE
Configurable audio filter mode & power LED off-state

### DIFF
--- a/rtl/minimig/minimig.v
+++ b/rtl/minimig/minimig.v
@@ -423,6 +423,8 @@ reg		[3:0] floppy_config;	//floppy drives configuration (drive number and speed)
 reg		[4:0] chipset_config;	//chipset features selection
 reg		[2:0] ide_config0;		//HDD & HDC config: bit #0 enables Gayle primary channel, bit #1 enables Master drive, bit #2 enables Slave drive
 reg		[2:0] ide_config1;		//HDD & HDC config: bit #0 enables Gayle secondary chnnl, bit #1 enables Master drive, bit #2 enables Slave drive
+wire	[1:0] audio_filter_mode;	//audio filter mode
+wire	pwr_led_dim_n;			//power LED dim at off-state
 
 //gayle stuff
 wire	sel_ide;				//select IDE drive registers
@@ -480,7 +482,7 @@ assign vblank_out = vbl_int;
 
 //assign pwrled = (_led & (led_dim | ~turbo)) ? 1'b0 : 1'b1; // led dim at off-state and active turbo mode
 //assign pwr_led = (_led & led_dim) ? 1'b0 : 1'b1; // led dim at off-state and active turbo mode
-assign pwr_led = (_led & !hblank_out) ? 1'b0 : 1'b1; // led dim at off-state and active turbo mode
+assign pwr_led = pwr_led_dim_n ? !_led : ((_led & !hblank_out) ? 1'b0 : 1'b1); // selectable led dim at off-state
 
 //assign memcfg = memory_config[5:0];
 
@@ -634,7 +636,7 @@ paula PAULA1
 	.secdisp(secdisp),
   .floppy_fwr (floppy_fwr),
   .floppy_frd (floppy_frd),
-  .filter(!_led)
+  .filter(~|audio_filter_mode ? !_led : audio_filter_mode[1])
 );
 
 wire	[6:0] userio_memory_config;	//memory configuration
@@ -711,6 +713,8 @@ userio USERIO1
 	.ide_config0(userio_ide_config0),
 	.ide_config1(userio_ide_config1),
 	.cpu_config(userio_cpu_config),
+	.audio_filter_mode(audio_filter_mode),
+	.pwr_led_dim_n(pwr_led_dim_n),
 	.usrrst(usrrst),
   .cpurst(cpurst),
   .cpuhlt(cpuhlt),

--- a/rtl/minimig/userio.v
+++ b/rtl/minimig/userio.v
@@ -78,6 +78,8 @@ module userio (
   output wire [  3-1:0] ide_config0,
   output wire [  3-1:0] ide_config1,
   output wire [  4-1:0] cpu_config,
+  output wire [  2-1:0] audio_filter_mode,
+  output wire           pwr_led_dim_n,
   output                usrrst,             // user reset from osd module
   output                cpurst,
   output                cpuhlt,
@@ -551,6 +553,8 @@ userio_osd osd1
   .cpu_config       (cpu_config),
   .autofire_config  (autofire_config),
   .cd32pad          (cd32pad),
+  .audio_filter_mode(audio_filter_mode),
+  .pwr_led_dim_n    (pwr_led_dim_n),
   .usrrst           (usrrst),
   .cpurst           (cpurst),
   .cpuhlt           (cpuhlt),

--- a/rtl/minimig/userio_osd.v
+++ b/rtl/minimig/userio_osd.v
@@ -34,6 +34,8 @@ module userio_osd
   output  reg [3:0] cpu_config = 0,
   output  reg [1:0] autofire_config = 0,
   output  reg       cd32pad = 0,
+  output  reg [1:0] audio_filter_mode = 0,
+  output  reg       pwr_led_dim_n = 0,
 	output	reg usrrst=1'b0,
   output reg cpurst=1'b1,
   output reg cpuhlt=1'b1,
@@ -294,6 +296,7 @@ localparam [5:0]
   SPI_HARDDISK0_CFG_ADR= 6'b0_101_01,
   SPI_HARDDISK1_CFG_ADR= 6'b0_101_10,
   SPI_JOYSTICK_CFG_ADR = 6'b0_110_01,
+  SPI_FEATURES_CFG_ADR = 6'b0_111_01,
   SPI_OSD_BUFFER_ADR   = 6'b0_000_11,
   SPI_MEM_WRITE_ADR    = 6'b0_001_11,
   SPI_VERSION_ADR      = 6'b1_000_10,
@@ -334,6 +337,7 @@ reg spi_floppy_cfg_sel    = 1'b0;
 reg spi_harddisk0_cfg_sel = 1'b0;
 reg spi_harddisk1_cfg_sel = 1'b0;
 reg spi_joystick_cfg_sel  = 1'b0;
+reg spi_features_cfg_sel  = 1'b0;
 reg spi_osd_buffer_sel    = 1'b0;
 reg spi_mem_write_sel     = 1'b0;
 reg spi_version_sel       = 1'b0;
@@ -350,6 +354,7 @@ always @ (*) begin
   spi_harddisk0_cfg_sel= 1'b0;
   spi_harddisk1_cfg_sel= 1'b0;
   spi_joystick_cfg_sel = 1'b0;
+  spi_features_cfg_sel = 1'b0;
   spi_osd_buffer_sel   = 1'b0;
   spi_mem_write_sel    = 1'b0;
   spi_version_sel      = 1'b0;
@@ -366,6 +371,7 @@ always @ (*) begin
     SPI_HARDDISK0_CFG_ADR: spi_harddisk0_cfg_sel= 1'b1;
     SPI_HARDDISK1_CFG_ADR: spi_harddisk1_cfg_sel= 1'b1;
     SPI_JOYSTICK_CFG_ADR : spi_joystick_cfg_sel = 1'b1;
+    SPI_FEATURES_CFG_ADR : spi_features_cfg_sel = 1'b1;
     SPI_OSD_BUFFER_ADR   : spi_osd_buffer_sel   = 1'b1;
     SPI_MEM_WRITE_ADR    : spi_mem_write_sel    = 1'b1;
     SPI_VERSION_ADR      : spi_version_sel      = 1'b1;
@@ -382,6 +388,7 @@ always @ (*) begin
       spi_harddisk0_cfg_sel= 1'b0;
       spi_harddisk1_cfg_sel= 1'b0;
       spi_joystick_cfg_sel = 1'b0;
+      spi_features_cfg_sel = 1'b0;
       spi_osd_buffer_sel   = 1'b0;
       spi_mem_write_sel    = 1'b0;
       spi_version_sel      = 1'b0;
@@ -400,6 +407,7 @@ end
 // 8'b0_100_0100 | XXXXXFFS || floppy config   | FF - drive number, S - floppy speed
 // 8'b0_101_0100 | XXXXXSMC || harddisk config | S - enable slave HDD, M - enable master HDD, C - enable HDD controler
 // 8'b0_110_0100 | XXXXXCAA || joystick config | C - CD32pad mode, AA - autofire rate
+// 8'b0_111_0100 | XXXXXPFF || features config | P - power LED dim/off at off-state, FF - audio filter mode (00=switchable with power LED, 01=always off, 10=always on)
 // 8'b0_000_1100 | XXXXXAAA_AAAAAAAA B,B,... || write OSD buffer, AAAAAAAAAAA - 11bit OSD buffer address, B - variable number of bytes
 // 8'b0_001_1100 | A_A_A_A B,B,... || write system memory, A - 32 bit memory address, B - variable number of bytes
 // 8'b1_000_1000 read RTL version
@@ -420,6 +428,7 @@ always @ (posedge clk) begin
       if (spi_harddisk0_cfg_sel)begin if (dat_cnt == 0) t_ide_config0 <= #1 wrdat[2:0]; end
       if (spi_harddisk1_cfg_sel)begin if (dat_cnt == 0) t_ide_config1 <= #1 wrdat[2:0]; end
       if (spi_joystick_cfg_sel) begin if (dat_cnt == 0) {cd32pad, autofire_config} <= #1 wrdat[2:0]; end
+      if (spi_features_cfg_sel) begin if (dat_cnt == 0) {pwr_led_dim_n, audio_filter_mode} <= #1 wrdat[2:0]; end
       //if (spi_joystick_cfg_sel) begin if (dat_cnt == 0) {autofire_config} <= #1 wrdat[1:0]; end
   //    if (spi_osd_buffer_sel)   begin if (dat_cnt == 3) highlight <= #1 wrdat[3:0]; end
   //    if (spi_mem_write_sel)    begin if (dat_cnt == 0) end


### PR DESCRIPTION
This adds a feature configuration command to Minimig for configurable audio filter mode & power LED off-state.
* Audio filter: switchable - always on - always off
* Power LED off: dim - off

With these options it is possible to configure several revisions of the Amiga:

|Amiga|Power LED off|Audio filter|
|--------|---------|----|
|A1000|off|always on|
|A500 rev 3|off|always on|
|A500 rev 5|off|switchable|
|A500 rev 6/7/8|dim|switchable|

(I don't know of the A2000 configurations...)

Additionally it's nice to have Audio filter always off option.

Now it is possible to enjoy some real old Amiga demos.
Although the Soundtracker docs warned

```
[...]
Filter:  This Soundtracker version allows you to turn the lo-pass filter
-------  on/off.

Example: G#2 1E01 - Turns the filter and the power-led off.
         --- 0000
         E-1 1E00 - Turns the filter and the power-led on.

Warning to all Amiga 1000 owners:  Don't play with the power-led because A500
and A2000 owners will not be happy when they hear your song.
[...]
```
some A1000 demos used this feature.

Here are two examples if you want to try it out: https://workupload.com/file/3vXjChfVyeV
